### PR TITLE
Add Jenkins Views role to official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ The Jenkins server must have the Nested Views plugin installed if you wish to us
 Example Playbook
 ----------------
 
+This playbook prompts for a Jenkins user name and password at runtime.
+
 ```
 - hosts: jenkins
-  remote_user: vagrant
   become: yes
 
   vars_prompt:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Requirements
 ------------
 
 - Jenkins on the server to load the views to
+- curl on the server (used to load the views)
 - a Jenkins username/password that can administer views
 
 Role Variables

--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-# ansible-jenkins-views
+=============
+Jenkins Views
+=============
+
+Creates and loads basic regex-based view configurations to a Jenkins server.
+
+Covers only the following at the moment:
+- List Views
+- Nested Views (with the Nested Views plugin)
+
+This is pretty much a task-oriented role right now that exists to avoid having to do a lot of manual work managing views in our own CI.
+
+Requirements
+------------
+
+- Jenkins on the server to load the views to
+- a Jenkins username/password that can administer views
+
+Role Variables
+--------------
+
+See defaults/main.yml for what's configurable.
+
+In the current state, you'll likely want to prompt for `jenkins_user` and `jenkins_password` as part of the playbook (see example playbook below).
+
+Dependencies
+------------
+
+The Jenkins server must have the Nested Views plugin installed if you wish to use Nested Views.
+
+Example Playbook
+----------------
+
+```
+- hosts: jenkins
+  remote_user: vagrant
+  become: yes
+
+  vars_prompt:
+    - name: jenkins_user
+      prompt: "Enter Jenkins user name"
+
+    - name: jenkins_password
+      prompt: "Enter Jenkins password"
+      private: yes
+
+  roles:
+    - role: jenkins-views
+      jenkins_nested_views:
+        - name: "Container Jobs"
+          child_views:
+            - name: "Build Containers"
+              regex: ".*build-container.*"
+            - name: "Deploy Containers"
+              regex: ".*deploy-container.*"
+        - name: "Admin Jobs"
+          description: "Administrative jobs for doing administrative things"
+          child_views:
+            - name: "Admin Jobs"
+              regex: ".*admin.*"
+        - name: "Websites"
+          description: "Various website jobs"
+          child_views:
+            - name: "IDRC"
+              description: "idrc.ocad sites"
+              regex: ".*idrc\\.ocad.*"
+            - name: "Floe"
+              regex: ".*floeproject\\.org.*"
+      jenkins_global_views:
+        - name: "All Container Jobs"
+          description: "All container jobs"
+          regex: ".*container.*"
+        - name: "All Non-Container Jobs"
+          regex: "(?!.*container).*"
+```
+
+License
+-------
+
+MIT

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# defaults file for ansible-jenkins-views
+
+jenkins_view_configs_directory: /var/lib/jenkins/view_configs
+
+jenkins_local_url: 127.0.0.1:8080
+
+jenkins_auth_details: "{{ jenkins_user }}:{{ jenkins_password }}"
+
+jenkins_local_url_with_auth: http://{{ jenkins_auth_details }}@{{ jenkins_local_url }}
+
+jenkins_upload_view_curl_command: "curl --fail -X POST -d @{{ jenkins_view_configs_directory}}/{{ item.name | urlencode() }}.xml -H \"Content-Type: text/xml\" {{ jenkins_local_url_with_auth }}/createView?name={{ item.name | urlencode() }}"
+
+jenkins_delete_view_curl_command: "curl -X POST {{ jenkins_local_url_with_auth }}/view/{{ item.name | urlencode() }}/doDelete"
+
+# These will typically needed to be supplied by a prompt or at runtime
+jenkins_user: jenkins
+jenkins_password: jenkins
+
+jenkins_nested_views: []
+jenkins_global_views: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ansible-jenkins-views

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  author: Inclusive Design Research Centre
+  description:
+  company: your company (optional)
+  license: MIT
+  min_ansible_version: 1.2
+
+  dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+# tasks file for ansible-jenkins-views
+
+# https://issues.jenkins-ci.org/browse/JENKINS-8927
+
+# Get (Read) a view config
+# curl aharnum:ChangeMe%@localhost:8080/view/All%20Container%20Jobs/config.xml
+
+# curl aharnum:ChangeMe%@localhost:8080/view/Admin%20Jobs/config.xml
+
+# Create a new view from an XML file
+# curl -vvv -X POST -d @nested_view.xml -H "Content-Type: text/xml" http://aharnum:ChangeMe%@localhost:8080/createView?name=MyView
+
+#
+
+# Update an existing view from an XML file
+# curl -X POST -d @nested_view.xml -H "Content-Type: text/xml" aharnum:ChangeMe%@localhost:8080/view/Container%20Jobs/config.xml
+
+# Delete an existing view
+# curl -X POST aharnum:ChangeMe%@192.168.88.10:8080/view/MyView/doDelete
+
+
+# ---
+
+# curl aharnum:ChangeMe%@localhost:8080/view/nestedView/config.xml
+
+- name: create directory for view definitions
+  file:
+    state: directory
+    path: "{{ jenkins_view_configs_directory }}"
+
+- name: deploy config template for nested views
+  template:
+    src: nested_view.j2
+    dest: "{{ jenkins_view_configs_directory}}/{{ item.name | urlencode() }}.xml"
+  with_items: "{{ jenkins_nested_views }}"
+
+- name: deploy config template for global views
+  template:
+    src: list_view.j2
+    dest: "{{ jenkins_view_configs_directory}}/{{ item.name | urlencode() }}.xml"
+  with_items: "{{ jenkins_global_views }}"
+
+- name: delete the old versions of any nested views we're replacing
+  command: "{{ jenkins_delete_view_curl_command }}"
+  with_items: "{{ jenkins_nested_views }}"
+
+- name: create nested views
+  command: "{{ jenkins_upload_view_curl_command }}"
+  with_items: "{{ jenkins_nested_views }}"
+
+- name: delete the old versions of any global views we're replacing
+  command: "{{ jenkins_delete_view_curl_command }}"
+  with_items: "{{ jenkins_global_views }}"
+
+- name: create global views
+  command: "{{ jenkins_upload_view_curl_command }}"
+  with_items: "{{ jenkins_global_views }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,4 @@
 ---
-# tasks file for ansible-jenkins-views
-
-# https://issues.jenkins-ci.org/browse/JENKINS-8927
-
-# Get (Read) a view config
-# curl aharnum:ChangeMe%@localhost:8080/view/All%20Container%20Jobs/config.xml
-
-# curl aharnum:ChangeMe%@localhost:8080/view/Admin%20Jobs/config.xml
-
-# Create a new view from an XML file
-# curl -vvv -X POST -d @nested_view.xml -H "Content-Type: text/xml" http://aharnum:ChangeMe%@localhost:8080/createView?name=MyView
-
-#
-
-# Update an existing view from an XML file
-# curl -X POST -d @nested_view.xml -H "Content-Type: text/xml" aharnum:ChangeMe%@localhost:8080/view/Container%20Jobs/config.xml
-
-# Delete an existing view
-# curl -X POST aharnum:ChangeMe%@192.168.88.10:8080/view/MyView/doDelete
-
-
-# ---
-
-# curl aharnum:ChangeMe%@localhost:8080/view/nestedView/config.xml
 
 - name: create directory for view definitions
   file:

--- a/templates/_view_macros.j2
+++ b/templates/_view_macros.j2
@@ -1,0 +1,27 @@
+{% macro list_view(name, regex, nested=false, description='') -%}
+<hudson.model.ListView>
+  <name>{{ name }}</name>
+  {% if description %}<description>{{ description }}</description>{% endif %}
+  {% if nested %}
+  <owner class="hudson.plugins.nested_view.NestedView" reference="../../.."/>
+  {% endif %}
+  <filterExecutors>false</filterExecutors>
+  <filterQueue>false</filterQueue>
+  <properties class="hudson.model.View$PropertyList"/>
+  <jobNames>
+    <comparator class="hudson.util.CaseInsensitiveComparator"/>
+  </jobNames>
+  <jobFilters/>
+  <columns>
+    <hudson.views.StatusColumn/>
+    <hudson.views.WeatherColumn/>
+    <hudson.views.JobColumn/>
+    <hudson.views.LastSuccessColumn/>
+    <hudson.views.LastFailureColumn/>
+    <hudson.views.LastDurationColumn/>
+    <hudson.views.BuildButtonColumn/>
+  </columns>
+  <includeRegex>{{ regex }}</includeRegex>
+  <recurse>false</recurse>
+</hudson.model.ListView>
+{%- endmacro %}

--- a/templates/list_view.j2
+++ b/templates/list_view.j2
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+{% import '_view_macros.j2' as view_macros with context %}
+{{ view_macros.list_view(item.name, item.regex, description=item.description|default('')) }}

--- a/templates/nested_view.j2
+++ b/templates/nested_view.j2
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hudson.plugins.nested__view.NestedView>
+  <name>{{ item.name }}</name>
+  <description>{{ item.description|default('') }}</description>
+  <filterExecutors>false</filterExecutors>
+  <filterQueue>false</filterQueue>
+  <properties class="hudson.model.View$PropertyList"/>
+  <views>
+    {% for child_view in item.child_views %}
+        {% import '_view_macros.j2' as view_macros with context %}
+        {{ view_macros.list_view(child_view.name, child_view.regex, nested=true, description=child_view.description|default('')) }}
+    {% endfor %}
+  </views>
+  <columns>
+    <columns/>
+  </columns>
+</hudson.plugins.nested__view.NestedView>

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ansible-jenkins-views


### PR DESCRIPTION
This is a bit primitive, but I don't think it's worth spending more time on right now. It works for my immediate use case / frustration.

Longer term I'd like us to be able to maintain a parallel set of views to our JJB definitions - I was hoping https://github.com/piyush0101/jenkins-view-builder might enable this but I found it too flaky.

I also think we should install https://wiki.jenkins-ci.org/display/JENKINS/Nested+View+Plugin as standard on our Jenkins servers - it makes it much easier to organize views of the jobs in a sane way.